### PR TITLE
feat: implement dark mode 

### DIFF
--- a/app/components/mode-toggle.tsx
+++ b/app/components/mode-toggle.tsx
@@ -28,7 +28,7 @@ export function ModeToggle() {
         <DropdownMenuItem onClick={() => setTheme(Theme.DARK)}>
           Dark
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme(Theme.SYSTEM)}>
+        <DropdownMenuItem onClick={() => setTheme(null)}>
           System
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/app/components/mode-toggle.tsx
+++ b/app/components/mode-toggle.tsx
@@ -1,0 +1,39 @@
+import { Moon, Sun } from "lucide-react";
+import { Theme, useTheme } from "remix-themes";
+
+import { Button } from "~/components/ui/button"; // Adjusted path
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu"; // Adjusted path
+
+export function ModeToggle() {
+  const [, setTheme] = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme(Theme.LIGHT)}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme(Theme.DARK)}>
+          Dark
+        </DropdownMenuItem>
+        {/* Optional: Add system theme option if desired, following shadcn example if they have it
+        <DropdownMenuItem onClick={() => setTheme(Theme.SYSTEM)}>
+          System
+        </DropdownMenuItem>
+        */}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/app/components/mode-toggle.tsx
+++ b/app/components/mode-toggle.tsx
@@ -1,13 +1,13 @@
 import { Moon, Sun } from "lucide-react";
 import { Theme, useTheme } from "remix-themes";
 
-import { Button } from "~/components/ui/button"; // Adjusted path
+import { Button } from "~/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "~/components/ui/dropdown-menu"; // Adjusted path
+} from "~/components/ui/dropdown-menu";
 
 export function ModeToggle() {
   const [, setTheme] = useTheme();
@@ -28,11 +28,9 @@ export function ModeToggle() {
         <DropdownMenuItem onClick={() => setTheme(Theme.DARK)}>
           Dark
         </DropdownMenuItem>
-        {/* Optional: Add system theme option if desired, following shadcn example if they have it
         <DropdownMenuItem onClick={() => setTheme(Theme.SYSTEM)}>
           System
         </DropdownMenuItem>
-        */}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/app/layouts/dashboard.tsx
+++ b/app/layouts/dashboard.tsx
@@ -11,9 +11,9 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "~/components/ui/breadcrumb";
-import { ModeToggle } from "~/components/mode-toggle"; // Added import
+import { ModeToggle } from "~/components/mode-toggle";
 
-interface BreadcrumbItemType { // Renamed to avoid conflict with BreadcrumbItem component
+interface BreadcrumbItemType {
   path: string;
   name: string;
 }
@@ -21,14 +21,13 @@ interface BreadcrumbItemType { // Renamed to avoid conflict with BreadcrumbItem 
 interface RouteMatch {
   pathname: string;
   handle?: {
-    crumb?: string; // Made crumb optional as it might not always be present
+    crumb?: string;
   };
 }
 
 export default function DashboardLayout() {
-  const { title } = useMeta(); // title is declared but not used, consider removing if not needed.
+  const { title } = useMeta();
   const matches = useMatches() as unknown as RouteMatch[];
-  // Only show breadcrumb for dashboard routes
   const isDashboardRoute = matches.some(match => match.pathname.startsWith('/dashboard'));
   
   if (!isDashboardRoute) { 
@@ -45,7 +44,6 @@ export default function DashboardLayout() {
   }
 
   const currentRoute = matches[matches.length - 1];
-  // console.log(currentRoute.pathname); // Original console.log
 
   return (
     <SidebarProvider>
@@ -53,16 +51,13 @@ export default function DashboardLayout() {
         <AppSidebar />
         <main className="flex-1 overflow-auto p-4">
           <div className="flex flex-col w-full mb-6 border-b border-gray-200 pb-4">
-            {/* Header section with SidebarTrigger, Breadcrumbs, and ModeToggle */}
-            <div className="flex items-center"> {/* Main flex container for header items */}
+            <div className="flex items-center">
               <SidebarTrigger />
-              <div className="h-5 w-px bg-gray-300 mx-3" /> {/* Separator with margin */}
+              <div className="h-5 w-px bg-gray-300 mx-3" />
               
-              {/* Breadcrumb container */}
-              <div className="flex-grow"> {/* Allow breadcrumb to take available space */}
+              <div className="flex-grow">
                 <Breadcrumb>
                   <BreadcrumbList>
-                    {/* Case 1: Not on /dashboard or /dashboard/ (i.e., a subpage like /dashboard/settings) */}
                     {currentRoute.pathname !== '/dashboard' && currentRoute.pathname !== '/dashboard/' && (
                       <>
                         <BreadcrumbItem>
@@ -72,12 +67,10 @@ export default function DashboardLayout() {
                             </Link>
                           </BreadcrumbLink>
                         </BreadcrumbItem>
-                        {/* Show separator only if there's a crumb for the current sub-page */}
                         {currentRoute.handle?.crumb && <BreadcrumbSeparator />}
                       </>
                     )}
                     
-                    {/* Current Page Name (from crumb) - shows on subpages or if /dashboard has a crumb */}
                     {currentRoute.handle?.crumb && (
                       <BreadcrumbItem>
                         <BreadcrumbPage className="text-sm font-medium">
@@ -86,7 +79,6 @@ export default function DashboardLayout() {
                       </BreadcrumbItem>
                     )}
 
-                    {/* Case 2: On /dashboard or /dashboard/ AND no specific crumb (is the dashboard index itself) */}
                     {(currentRoute.pathname === '/dashboard' || currentRoute.pathname === '/dashboard/') && !currentRoute.handle?.crumb && (
                        <BreadcrumbItem>
                          <BreadcrumbPage className="text-sm font-medium">
@@ -98,8 +90,7 @@ export default function DashboardLayout() {
                 </Breadcrumb>
               </div>
 
-              {/* ModeToggle pushed to the right */}
-              <div className="ml-4"> {/* Margin to separate from breadcrumbs/flex-grow */}
+              <div className="ml-4">
                 <ModeToggle />
               </div>
             </div>

--- a/app/layouts/dashboard.tsx
+++ b/app/layouts/dashboard.tsx
@@ -11,9 +11,9 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "~/components/ui/breadcrumb";
+import { ModeToggle } from "~/components/mode-toggle"; // Added import
 
-
-interface BreadcrumbItem {
+interface BreadcrumbItemType { // Renamed to avoid conflict with BreadcrumbItem component
   path: string;
   name: string;
 }
@@ -21,17 +21,17 @@ interface BreadcrumbItem {
 interface RouteMatch {
   pathname: string;
   handle?: {
-    crumb: string;
+    crumb?: string; // Made crumb optional as it might not always be present
   };
 }
 
 export default function DashboardLayout() {
-  const { title } = useMeta();
+  const { title } = useMeta(); // title is declared but not used, consider removing if not needed.
   const matches = useMatches() as unknown as RouteMatch[];
   // Only show breadcrumb for dashboard routes
   const isDashboardRoute = matches.some(match => match.pathname.startsWith('/dashboard'));
   
-  if (!isDashboardRoute) {
+  if (!isDashboardRoute) { 
     return (
       <SidebarProvider>
         <div className="flex h-screen w-full">
@@ -44,63 +44,64 @@ export default function DashboardLayout() {
     );
   }
 
-  const pathnames: BreadcrumbItem[] = [];
   const currentRoute = matches[matches.length - 1];
-  
-  // Only add dashboard if we're not on the dashboard
-  if (currentRoute.pathname !== '/dashboard') {
-    pathnames.push({
-      path: '/dashboard',
-      name: 'Tableau de bord'
-    });
-  }
-  
-  // Add current route if it's not the dashboard and has a crumb
-  if (currentRoute.handle?.crumb) {
-    pathnames.push({
-      path: currentRoute.pathname,
-      name: currentRoute.handle.crumb
-    });
-  }
-  console.log(currentRoute.pathname);
+  // console.log(currentRoute.pathname); // Original console.log
+
   return (
     <SidebarProvider>
       <div className="flex h-screen w-full">
         <AppSidebar />
         <main className="flex-1 overflow-auto p-4">
           <div className="flex flex-col w-full mb-6 border-b border-gray-200 pb-4">
-            <div className="flex items-center space-x-2">
+            {/* Header section with SidebarTrigger, Breadcrumbs, and ModeToggle */}
+            <div className="flex items-center"> {/* Main flex container for header items */}
               <SidebarTrigger />
-              {pathnames.length > 0 && (
-                <>
-                  <div className="h-5 w-px bg-gray-300" />
-                  <div>
-                    <Breadcrumb>
-                      <BreadcrumbList>
-                        {currentRoute.pathname !== '/dashboard/' && (
-                          <BreadcrumbItem>
-                            <BreadcrumbLink asChild>
-                              <Link to="/dashboard" className="text-sm hover:underline font-medium">
-                                Tableau de bord
-                              </Link>
-                            </BreadcrumbLink>
-                          </BreadcrumbItem>
-                        )}
-                        {pathnames.length > 1 && (
-                          <>
-                            {currentRoute.pathname !== '/dashboard/' && <BreadcrumbSeparator />}
-                            <BreadcrumbItem>
-                              <BreadcrumbPage className="text-sm font-medium">
-                                {pathnames[pathnames.length - 1].name}
-                              </BreadcrumbPage>
-                            </BreadcrumbItem>
-                          </>
-                        )}
-                      </BreadcrumbList>
-                    </Breadcrumb>
-                  </div>
-                </>
-              )}
+              <div className="h-5 w-px bg-gray-300 mx-3" /> {/* Separator with margin */}
+              
+              {/* Breadcrumb container */}
+              <div className="flex-grow"> {/* Allow breadcrumb to take available space */}
+                <Breadcrumb>
+                  <BreadcrumbList>
+                    {/* Case 1: Not on /dashboard or /dashboard/ (i.e., a subpage like /dashboard/settings) */}
+                    {currentRoute.pathname !== '/dashboard' && currentRoute.pathname !== '/dashboard/' && (
+                      <>
+                        <BreadcrumbItem>
+                          <BreadcrumbLink asChild>
+                            <Link to="/dashboard" className="text-sm hover:underline font-medium">
+                              Tableau de bord
+                            </Link>
+                          </BreadcrumbLink>
+                        </BreadcrumbItem>
+                        {/* Show separator only if there's a crumb for the current sub-page */}
+                        {currentRoute.handle?.crumb && <BreadcrumbSeparator />}
+                      </>
+                    )}
+                    
+                    {/* Current Page Name (from crumb) - shows on subpages or if /dashboard has a crumb */}
+                    {currentRoute.handle?.crumb && (
+                      <BreadcrumbItem>
+                        <BreadcrumbPage className="text-sm font-medium">
+                          {currentRoute.handle.crumb}
+                        </BreadcrumbPage>
+                      </BreadcrumbItem>
+                    )}
+
+                    {/* Case 2: On /dashboard or /dashboard/ AND no specific crumb (is the dashboard index itself) */}
+                    {(currentRoute.pathname === '/dashboard' || currentRoute.pathname === '/dashboard/') && !currentRoute.handle?.crumb && (
+                       <BreadcrumbItem>
+                         <BreadcrumbPage className="text-sm font-medium">
+                           Tableau de bord
+                         </BreadcrumbPage>
+                       </BreadcrumbItem>
+                    )}
+                  </BreadcrumbList>
+                </Breadcrumb>
+              </div>
+
+              {/* ModeToggle pushed to the right */}
+              <div className="ml-4"> {/* Margin to separate from breadcrumbs/flex-grow */}
+                <ModeToggle />
+              </div>
             </div>
           </div>
           <Outlet />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,13 +6,18 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  useRouteError, // Added
 } from "react-router";
 
-import type { Route } from "./+types/root";
+import type { Route } from "./+types/root"; // Project-specific
 import stylesheet from "./app.css?url";
-import { SidebarProvider } from "./components/ui/sidebar";
-import { Toaster } from "./components/ui/toaster";
+import { Toaster } from "./components/ui/toaster"; // Keep Toaster
 import { getSession } from "./services/session.server";
+
+// Theme imports
+import clsx from "clsx";
+import { PreventFlashOnWrongTheme, ThemeProvider, useTheme } from "remix-themes";
+import { themeSessionResolver } from "./services/session.server";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -29,23 +34,31 @@ export const links: Route.LinksFunction = () => [
 ];
 
 export const loader = async ({ request }: { request: Request }) => {
+  const { getTheme } = await themeSessionResolver(request);
   const session = await getSession(request);
   const user = session.get("user");
-  return { user };
+  return {
+    theme: getTheme(),
+    user,
+  };
 };
 
-export function Layout({ children }: { children: React.ReactNode }) {
-  const loaderData = useLoaderData<typeof loader>();
+// Component that renders the actual HTML structure
+function AppBody() {
+  const data = useLoaderData<typeof loader>();
+  const [theme] = useTheme(); // Hook to get theme from context
   return (
-    <html lang="en">
+    <html lang="en" className={clsx(theme)}> {/* theme from context is preferred */}
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
+        {/* ssrTheme from loader is used by PreventFlashOnWrongTheme */}
+        <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} />
         <Links />
       </head>
       <body>
-        {children}
+        <Outlet />
         <Toaster />
         <ScrollRestoration />
         <Scripts />
@@ -54,11 +67,20 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
+// Default export component that wraps AppBody with ThemeProvider
 export default function App() {
-  return <Outlet />;
+  const data = useLoaderData<typeof loader>();
+  return (
+    <ThemeProvider specifiedTheme={data.theme} themeAction="/action/set-theme">
+      <AppBody />
+    </ThemeProvider>
+  );
 }
 
-export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const data = useLoaderData<typeof loader>(); // Loader data should still be available for the theme
+
   let message = "Oops!";
   let details = "An unexpected error occurred.";
   let stack: string | undefined;
@@ -69,20 +91,36 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
       error.status === 404
         ? "The requested page could not be found."
         : error.statusText || details;
-  } else if (import.meta.env.DEV && error && error instanceof Error) {
+  } else if (error instanceof Error) { // Check if error is an instance of Error
     details = error.message;
-    stack = error.stack;
+    if (import.meta.env.DEV) { // Only include stack in development
+        stack = error.stack;
+    }
   }
 
   return (
-    <main className="pt-16 p-4 container mx-auto">
-      <h1>{message}</h1>
-      <p>{details}</p>
-      {stack && (
-        <pre className="w-full p-4 overflow-x-auto">
-          <code>{stack}</code>
-        </pre>
-      )}
-    </main>
+    // Apply theme from loader data. Fallback to a default if not available.
+    <html lang="en" className={clsx(data?.theme)}>
+      <head>
+        <title>{message}</title>
+        <Meta />
+        {/* Also include PreventFlashOnWrongTheme in ErrorBoundary if theme data is available */}
+        {data?.theme !== undefined && <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} />}
+        <Links />
+      </head>
+      <body>
+        <main className="pt-16 p-4 container mx-auto">
+          <h1>{message}</h1>
+          <p>{details}</p>
+          {stack && (
+            <pre className="w-full p-4 overflow-x-auto">
+              <code>{stack}</code>
+            </pre>
+          )}
+        </main>
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
   );
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,15 +6,14 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
-  useRouteError, // Added
+  useRouteError,
 } from "react-router";
 
-import type { Route } from "./+types/root"; // Project-specific
+import type { Route } from "./+types/root";
 import stylesheet from "./app.css?url";
-import { Toaster } from "./components/ui/toaster"; // Keep Toaster
+import { Toaster } from "./components/ui/toaster";
 import { getSession } from "./services/session.server";
 
-// Theme imports
 import clsx from "clsx";
 import { PreventFlashOnWrongTheme, ThemeProvider, useTheme } from "remix-themes";
 import { themeSessionResolver } from "./services/session.server";
@@ -46,14 +45,13 @@ export const loader = async ({ request }: { request: Request }) => {
 // Component that renders the actual HTML structure
 function AppBody() {
   const data = useLoaderData<typeof loader>();
-  const [theme] = useTheme(); // Hook to get theme from context
+  const [theme] = useTheme();
   return (
-    <html lang="en" className={clsx(theme)}> {/* theme from context is preferred */}
+    <html lang="en" className={clsx(theme)}>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
-        {/* ssrTheme from loader is used by PreventFlashOnWrongTheme */}
         <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} />
         <Links />
       </head>
@@ -79,7 +77,7 @@ export default function App() {
 
 export function ErrorBoundary() {
   const error = useRouteError();
-  const data = useLoaderData<typeof loader>(); // Loader data should still be available for the theme
+  const data = useLoaderData<typeof loader>();
 
   let message = "Oops!";
   let details = "An unexpected error occurred.";
@@ -91,20 +89,18 @@ export function ErrorBoundary() {
       error.status === 404
         ? "The requested page could not be found."
         : error.statusText || details;
-  } else if (error instanceof Error) { // Check if error is an instance of Error
+  } else if (error instanceof Error) {
     details = error.message;
-    if (import.meta.env.DEV) { // Only include stack in development
+    if (import.meta.env.DEV) {
         stack = error.stack;
     }
   }
 
   return (
-    // Apply theme from loader data. Fallback to a default if not available.
     <html lang="en" className={clsx(data?.theme)}>
       <head>
         <title>{message}</title>
         <Meta />
-        {/* Also include PreventFlashOnWrongTheme in ErrorBoundary if theme data is available */}
         {data?.theme !== undefined && <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} />}
         <Links />
       </head>

--- a/app/routes/action.set-theme.ts
+++ b/app/routes/action.set-theme.ts
@@ -1,0 +1,4 @@
+import { createThemeAction } from "remix-themes";
+import { themeSessionResolver } from "~/services/session.server"; // Corrected path
+
+export const action = createThemeAction(themeSessionResolver);

--- a/app/routes/action.set-theme.ts
+++ b/app/routes/action.set-theme.ts
@@ -1,4 +1,4 @@
 import { createThemeAction } from "remix-themes";
-import { themeSessionResolver } from "~/services/session.server"; // Corrected path
+import { themeSessionResolver } from "~/services/session.server";
 
 export const action = createThemeAction(themeSessionResolver);

--- a/app/services/session.server.ts
+++ b/app/services/session.server.ts
@@ -1,5 +1,5 @@
 import { createCookieSessionStorage } from "@remix-run/node";
-import { createThemeSessionResolver } from "remix-themes"; // Added
+import { createThemeSessionResolver } from "remix-themes";
 
 export const sessionStorage = createCookieSessionStorage({
   cookie: {

--- a/app/services/session.server.ts
+++ b/app/services/session.server.ts
@@ -1,4 +1,5 @@
 import { createCookieSessionStorage } from "@remix-run/node";
+import { createThemeSessionResolver } from "remix-themes"; // Added
 
 export const sessionStorage = createCookieSessionStorage({
   cookie: {

--- a/app/services/session.server.ts
+++ b/app/services/session.server.ts
@@ -7,7 +7,7 @@ export const sessionStorage = createCookieSessionStorage({
     httpOnly: true,
     path: "/",
     sameSite: "lax",
-    secrets: [process.env.SESSION_SECRET],
+    secrets: [process.env.SESSION_SECRET!], 
     secure: process.env.NODE_ENV === "production",
   },
 });
@@ -26,7 +26,13 @@ export async function destroySession(session: any) {
 
 export async function getError(request: Request) {
   const session = await getSession(request);
-  const error = session.get("error") as string | null;
+  const error = session.get("error") as string | null; 
   session.unset("error");
+  // Consider committing session here if unset should persist immediately:
+  // await commitSession(session); 
   return error;
 }
+
+// This is the crucial part for remix-themes:
+// It uses the `sessionStorage` defined above.
+export const themeSessionResolver = createThemeSessionResolver(sessionStorage);

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "recharts": "^2.15.3",
     "remix-auth": "^4.2.0",
     "remix-auth-form": "^3.0.0",
+    "remix-themes": "^2.0.4",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^3.4.17",


### PR DESCRIPTION
Add a dark mode functionality to leverage shadcn components possibilities.
Use `remix-themes`
the button shows an icon of the current state and displays a dropdown with theme options when clicked