### PR TITLE
feat: search functionality

### DIFF
--- a/.react-router/types/+register.ts
+++ b/.react-router/types/+register.ts
@@ -17,4 +17,6 @@ type Params = {
   "/auth/logout": {};
   "/dashboard": {};
   "/dashboard/account": {};
+  "/api": {};
+  "/api/search": {};
 };

--- a/app/components/search-bar.test.tsx
+++ b/app/components/search-bar.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useNavigate } from 'react-router-dom'; // Using MemoryRouter for navigation context
+import { SearchBar } from './search-bar'; // Adjust path as necessary
+// Mock fetch directly
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock useNavigate
+const mockNavigate = vi.fn();
+
+// Mocking @remix-run/react first as it's more specific to the project
+vi.mock('@remix-run/react', async () => {
+    const actual = await vi.importActual('@remix-run/react');
+    return {
+        ...(actual as any),
+        useNavigate: () => mockNavigate,
+    };
+});
+
+// Mock react-router-dom if it's also used for useNavigate, though Remix's should take precedence.
+// If only Remix's useNavigate is used, this mock might be redundant but harmless.
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...(actual as any),
+    useNavigate: () => mockNavigate, // Fallback, Remix's should be primary
+  };
+});
+
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  mockNavigate.mockClear();
+});
+
+const mockSearchResults = [
+  { type: 'post', data: { id: 'post1', description: 'Test Post 1' } },
+  { type: 'reportedEntity', data: { id: 're1', name: 'Test Entity 1' } },
+  { type: 'user', data: { id: 'user1', firstName: 'John', lastName: 'Doe' } },
+];
+
+describe('SearchBar Component', () => {
+  const TestWrapper = ({ children } : {children: React.ReactNode}) => <MemoryRouter>{children}</MemoryRouter>;
+
+  it('renders the search input', () => {
+    render(<SearchBar />, { wrapper: TestWrapper });
+    expect(screen.getByPlaceholderText('Search posts, entities, users...')).toBeInTheDocument();
+  });
+
+  it('fetches and displays results when user types', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockSearchResults,
+    } as Response);
+
+    render(<SearchBar />, { wrapper: TestWrapper });
+    const input = screen.getByPlaceholderText('Search posts, entities, users...');
+    await userEvent.type(input, 'test');
+
+    // Wait for debouncing and API call
+    await waitFor(() => {
+      expect(screen.getByText('Test Post 1')).toBeInTheDocument();
+    }, { timeout: 1000 });
+
+    expect(screen.getByText('Test Entity 1')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledWith('/api/search?q=test');
+  });
+
+  it('shows "No results found" message when API returns empty array for a search term', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+    
+    render(<SearchBar />, { wrapper: TestWrapper });
+    const input = screen.getByPlaceholderText('Search posts, entities, users...');
+    await userEvent.type(input, 'nonexistent');
+    
+    await waitFor(() => {
+      expect(screen.getByText(/No results found for "nonexistent"./i)).toBeInTheDocument();
+    }, { timeout: 1000 });
+    expect(mockFetch).toHaveBeenCalledWith('/api/search?q=nonexistent');
+  });
+  
+  it('shows "Type to start searching." message when input is empty and not loading', async () => {
+    render(<SearchBar />, { wrapper: TestWrapper });
+    const input = screen.getByPlaceholderText('Search posts, entities, users...');
+    
+    // Focus the input to open the command list if it's designed to do so
+    fireEvent.focus(input);
+
+    // Initially, without typing, it should show "Type to start searching."
+    await waitFor(() => {
+        expect(screen.getByText("Type to start searching.")).toBeInTheDocument();
+    });
+
+    // Type something to get results
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockSearchResults,
+    } as Response);
+    await userEvent.type(input, 'test');
+     await waitFor(() => {
+      expect(screen.getByText('Test Post 1')).toBeInTheDocument();
+    });
+    expect(mockFetch).toHaveBeenCalledWith('/api/search?q=test');
+    
+    // Clear the input
+    await userEvent.clear(input);
+     await waitFor(() => {
+        expect(screen.getByText("Type to start searching.")).toBeInTheDocument();
+    });
+
+  });
+
+
+  it('navigates to the correct path when a post result is selected', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [mockSearchResults[0]], // Return only post
+    } as Response);
+
+    render(<SearchBar />, { wrapper: TestWrapper });
+    const input = screen.getByPlaceholderText('Search posts, entities, users...');
+    await userEvent.type(input, 'Test Post 1');
+
+    await waitFor(() => screen.getByText('Test Post 1'));
+    
+    // Click the item. Use the text content to find it.
+    // `CommandItem` might not directly be a button, so we find by text and click its parent or the item itself.
+    const resultItem = screen.getByText('Test Post 1');
+    await userEvent.click(resultItem);
+    
+    expect(mockNavigate).toHaveBeenCalledWith('/posts/post1');
+    expect(mockFetch).toHaveBeenCalledWith('/api/search?q=Test Post 1');
+  });
+
+  it('navigates to the correct path when a reported entity result is selected', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [mockSearchResults[1]], // Return only entity
+    } as Response);
+
+    render(<SearchBar />, { wrapper: TestWrapper });
+    await userEvent.type(screen.getByPlaceholderText('Search posts, entities, users...'), 'Test Entity 1');
+    await waitFor(() => screen.getByText('Test Entity 1'));
+    await userEvent.click(screen.getByText('Test Entity 1'));
+    expect(mockNavigate).toHaveBeenCalledWith('/reported-entities/re1');
+    expect(mockFetch).toHaveBeenCalledWith('/api/search?q=Test Entity 1');
+  });
+
+  it('navigates to the correct path when a user result is selected', async () => {
+     mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [mockSearchResults[2]], // Return only user
+    } as Response);
+
+    render(<SearchBar />, { wrapper: TestWrapper });
+    await userEvent.type(screen.getByPlaceholderText('Search posts, entities, users...'), 'John Doe');
+    await waitFor(() => screen.getByText('John Doe'));
+    await userEvent.click(screen.getByText('John Doe'));
+    expect(mockNavigate).toHaveBeenCalledWith('/users/user1');
+    expect(mockFetch).toHaveBeenCalledWith('/api/search?q=John Doe');
+  });
+  
+  it('debounces API calls', async () => {
+    mockFetch.mockResolvedValue({ // General mock for this test
+      ok: true,
+      json: async () => [], 
+    } as Response);
+
+    render(<SearchBar />, { wrapper: TestWrapper });
+    const input = screen.getByPlaceholderText('Search posts, entities, users...');
+
+    await userEvent.type(input, 't');
+    await userEvent.type(input, 'e');
+    await userEvent.type(input, 's');
+    // API should not have been called yet due to debouncing
+    expect(mockFetch).not.toHaveBeenCalled();
+    
+    await userEvent.type(input, 't');
+    
+    // Wait for the debounce timeout (500ms) + a bit more
+    await new Promise(resolve => setTimeout(resolve, 700)); 
+
+    expect(mockFetch).toHaveBeenCalledTimes(1); 
+    expect(mockFetch).toHaveBeenCalledWith('/api/search?q=test');
+
+    // Type again after debounce
+    mockFetch.mockClear(); // Clear previous calls for the next assertion
+    await userEvent.type(input, 'a');
+     await new Promise(resolve => setTimeout(resolve, 700));
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith('/api/search?q=testa');
+  });
+});

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
-import { useNavigate } from "@remix-run/react";
+import { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router";
 import {
   Command,
   CommandInput,
@@ -8,12 +8,9 @@ import {
   CommandEmpty,
   CommandGroup,
 } from "~/components/ui/command";
-import { FileText, User, ShieldAlert, Loader2, Search as SearchIcon } from "lucide-react";
+import { FileText, ShieldAlert, Loader2 } from "lucide-react";
 import { useSearch } from "~/hooks/useSearch"; // Import the new hook
 
-// Define types for results based on the API response structure
-// These types should ideally come from useSearch.ts or a shared types file if they are identical.
-// For now, defining them here to match what useSearch hook expects/returns if not already globally available.
 interface SearchResultItemData {
   id: string;
   description?: string; 
@@ -28,11 +25,10 @@ interface SearchResult {
   type: string; 
   data: SearchResultItemData;
 }
-// End of type definitions that might be duplicated from useSearch.ts
 
 export function SearchBar() {
   const { searchTerm, setSearchTerm, results, loading } = useSearch();
-  const [isOpen, setIsOpen] = useState(false); // isOpen state is local to the SearchBar for UI presentation
+  const [isOpen, setIsOpen] = useState(false);
 
   const navigate = useNavigate();
   const commandRef = useRef<HTMLDivElement>(null);
@@ -67,12 +63,9 @@ export function SearchBar() {
       return;
     }
     let path = "";
-    // Note: The `useSearch` hook currently does not return 'user' type results.
-    // If user search is re-added to the API, this switch should handle it.
     switch (result.type) {
       case "post": path = `/posts/${result.data.id}`; break;
       case "reportedEntity": path = `/reported-entities/${result.data.id}`; break;
-      // case "user": path = `/users/${result.data.id}`; break; // User search was removed from API
       default: console.warn("Unknown result type for navigation:", result.type); return;
     }
     
@@ -89,9 +82,6 @@ export function SearchBar() {
         return { text: result.data.description || "Untitled Post", icon: <FileText className={iconClass} /> };
       case "reportedEntity":
         return { text: result.data.name || "Unnamed Entity", icon: <ShieldAlert className={iconClass} /> };
-      // case "user": // User search was removed from API
-      //   const name = `${result.data.firstName || ""} ${result.data.lastName || ""}`.trim();
-      //   return { text: name || result.data.instagram || "Unnamed User", icon: <User className={iconClass} /> };
       default:
         // Handle potentially unknown types gracefully if API changes or returns unexpected data
         return { text: result.data.name || result.data.description || "Unknown item", icon: null };
@@ -99,7 +89,6 @@ export function SearchBar() {
   };
   
   const handleInputFocus = () => {
-    // Open if there's already a search term or if there are results/loading
     if (searchTerm.trim() || results.length > 0 || loading) {
       setIsOpen(true);
     }
@@ -122,7 +111,6 @@ export function SearchBar() {
     <div ref={commandRef} className="relative w-full max-w-xl mx-auto">
       <Command shouldFilter={false} className="rounded-lg border shadow-md bg-card text-card-foreground">
         <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-          <SearchIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
           <CommandInput
             ref={inputRef}
             value={searchTerm}

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -1,7 +1,183 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useNavigate } from "@remix-run/react";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandItem,
+  CommandEmpty,
+  CommandGroup,
+} from "~/components/ui/command";
+import { FileText, User, ShieldAlert, Loader2, Search as SearchIcon } from "lucide-react";
+import { useSearch } from "~/hooks/useSearch"; // Import the new hook
+
+// Define types for results based on the API response structure
+// These types should ideally come from useSearch.ts or a shared types file if they are identical.
+// For now, defining them here to match what useSearch hook expects/returns if not already globally available.
+interface SearchResultItemData {
+  id: string;
+  description?: string; 
+  name?: string;        
+  firstName?: string;   
+  lastName?: string;    
+  instagram?: string;   
+  [key: string]: any; 
+}
+
+interface SearchResult {
+  type: string; 
+  data: SearchResultItemData;
+}
+// End of type definitions that might be duplicated from useSearch.ts
+
 export function SearchBar() {
+  const { searchTerm, setSearchTerm, results, loading } = useSearch();
+  const [isOpen, setIsOpen] = useState(false); // isOpen state is local to the SearchBar for UI presentation
+
+  const navigate = useNavigate();
+  const commandRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Effect to open/close the list based on search term and results
+  useEffect(() => {
+    if (searchTerm.trim() && (results.length > 0 || loading)) {
+      setIsOpen(true);
+    } else if (!searchTerm.trim() && results.length === 0 && !loading) {
+      // Close if search term is cleared and no results/loading
+      // but don't close if it's just loading with an empty term for the first time.
+      // setIsOpen(false); // This might be too aggressive, let onFocus/onBlur/clickOutside handle it mostly.
+    }
+  }, [searchTerm, results, loading]);
+
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (commandRef.current && !commandRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelectResult = (result: SearchResult) => {
+    if (!result?.data?.id) {
+      console.error("Selected result is invalid:", result);
+      return;
+    }
+    let path = "";
+    // Note: The `useSearch` hook currently does not return 'user' type results.
+    // If user search is re-added to the API, this switch should handle it.
+    switch (result.type) {
+      case "post": path = `/posts/${result.data.id}`; break;
+      case "reportedEntity": path = `/reported-entities/${result.data.id}`; break;
+      // case "user": path = `/users/${result.data.id}`; break; // User search was removed from API
+      default: console.warn("Unknown result type for navigation:", result.type); return;
+    }
+    
+    navigate(path);
+    setSearchTerm(""); // Clear input using the hook's setter
+    setIsOpen(false); // Close dropdown
+    // Results will clear automatically via the hook when searchTerm changes
+  };
+
+  const getResultDisplayData = (result: SearchResult) => {
+    const iconClass = "mr-2.5 h-4 w-4 flex-shrink-0 text-muted-foreground";
+    switch (result.type) {
+      case "post":
+        return { text: result.data.description || "Untitled Post", icon: <FileText className={iconClass} /> };
+      case "reportedEntity":
+        return { text: result.data.name || "Unnamed Entity", icon: <ShieldAlert className={iconClass} /> };
+      // case "user": // User search was removed from API
+      //   const name = `${result.data.firstName || ""} ${result.data.lastName || ""}`.trim();
+      //   return { text: name || result.data.instagram || "Unnamed User", icon: <User className={iconClass} /> };
+      default:
+        // Handle potentially unknown types gracefully if API changes or returns unexpected data
+        return { text: result.data.name || result.data.description || "Unknown item", icon: null };
+    }
+  };
+  
+  const handleInputFocus = () => {
+    // Open if there's already a search term or if there are results/loading
+    if (searchTerm.trim() || results.length > 0 || loading) {
+      setIsOpen(true);
+    }
+  };
+  
+  const handleInputChange = (newSearchTerm: string) => {
+    setSearchTerm(newSearchTerm);
+    if (newSearchTerm.trim() && !isOpen) {
+        setIsOpen(true);
+    } else if (!newSearchTerm.trim() && !loading && results.length === 0) {
+        // If input is cleared, and not loading, and no results, keep it open to show "Type to search"
+        // but allow click outside or blur to close it.
+        // Or, if you prefer to close it immediately:
+        // setIsOpen(false);
+    }
+  };
+
+
   return (
-    <div>
-      <input type="text" placeholder="Search..." />
+    <div ref={commandRef} className="relative w-full max-w-xl mx-auto">
+      <Command shouldFilter={false} className="rounded-lg border shadow-md bg-card text-card-foreground">
+        <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+          <SearchIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+          <CommandInput
+            ref={inputRef}
+            value={searchTerm}
+            onValueChange={handleInputChange}
+            placeholder="Search posts, entities..." // Updated placeholder
+            className="flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            onFocus={handleInputFocus}
+          />
+        </div>
+        {isOpen && (
+          <CommandList className="absolute top-full mt-1 w-full bg-card border rounded-b-lg shadow-lg max-h-[350px] overflow-y-auto z-50">
+            {loading && (
+              <div className="p-3 flex items-center justify-center text-sm text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <span>Searching...</span>
+              </div>
+            )}
+            {!loading && !results.length && searchTerm.trim() && (
+              <CommandEmpty className="p-4 text-sm text-center text-muted-foreground">
+                No results found for "{searchTerm}".
+              </CommandEmpty>
+            )}
+            {!loading && !results.length && !searchTerm.trim() && (
+              <CommandEmpty className="p-4 text-sm text-center text-muted-foreground">
+                Type to start searching.
+              </CommandEmpty>
+            )}
+            {!loading && results.length > 0 && (
+              <CommandGroup
+                heading={
+                  <div className="px-3 py-2 text-xs font-medium text-muted-foreground border-b">
+                    Results
+                  </div>
+                }
+                className="pt-0" 
+              >
+                {results.map((result) => {
+                  const { text, icon } = getResultDisplayData(result);
+                  return (
+                    <CommandItem
+                      key={`${result.type}-${result.data.id}`}
+                      onSelect={() => handleSelectResult(result)}
+                      value={`searchItem-${result.type}-${result.data.id}-${text}`}
+                      className="flex items-center cursor-pointer select-none rounded-sm px-3 py-2.5 text-sm hover:bg-accent aria-selected:bg-accent"
+                    >
+                      {icon}
+                      <span className="truncate flex-grow">{text}</span>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            )}
+          </CommandList>
+        )}
+      </Command>
     </div>
   );
 }

--- a/app/hooks/useSearch.ts
+++ b/app/hooks/useSearch.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect, useCallback } from 'react';
+import debounce from 'lodash-es/debounce';
+
+// Define types for results based on the API response structure
+// The API returns an array of objects, each with a 'type' and 'data' field.
+// 'data' can be of various shapes (Post, ReportedEntity, etc.)
+interface SearchResultItemData {
+  id: string;
+  // Common fields, specific fields depend on the 'type'
+  description?: string; // For Post
+  name?: string;        // For ReportedEntity
+  // Add other potential fields from different data types if known, or keep it general
+  [key: string]: any; 
+}
+
+interface SearchResultItem {
+  type: string; // e.g., "post", "reportedEntity"
+  data: SearchResultItemData;
+}
+
+type SearchResults = SearchResultItem[];
+
+export function useSearch() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [results, setResults] = useState<SearchResults>([]);
+  const [loading, setLoading] = useState(false);
+
+  // useCallback for fetchResults to memoize it unless dependencies change.
+  // Here, it has no dependencies other than what's available in its scope (fetch, setResults, setLoading).
+  const fetchResults = useCallback(async (query: string) => {
+    if (!query.trim()) { // Check if the query is empty or just whitespace
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
+      if (!response.ok) {
+        // You might want to handle different HTTP error statuses differently
+        console.error(`Search API request failed with status: ${response.status}`);
+        throw new Error('Network response was not ok');
+      }
+      const data: SearchResults = await response.json();
+      setResults(data); // API returns an array directly
+    } catch (error) {
+      console.error("Failed to fetch search results:", error);
+      setResults([]); // Clear results on error to avoid displaying stale/incorrect data
+    } finally {
+      setLoading(false);
+    }
+  }, []); // Empty dependency array as fetchResults doesn't depend on props/state from useSearch's scope directly
+
+  // useCallback for debouncedFetchResults to memoize the debounced function.
+  // The dependency array includes fetchResults, so if fetchResults changes, the debounced function is recreated.
+  const debouncedFetchResults = useCallback(debounce(fetchResults, 500), [fetchResults]);
+
+  useEffect(() => {
+    // Call the debounced function when searchTerm changes.
+    // If searchTerm is empty, debouncedFetchResults will call fetchResults with an empty query,
+    // which will then clear results and set loading to false.
+    debouncedFetchResults(searchTerm);
+
+    // Cleanup function:
+    // This will be called when the component unmounts or before the effect runs again.
+    // It's good practice to cancel any pending debounced calls to prevent them from
+    // executing (e.g., updating state on an unmounted component).
+    return () => {
+      debouncedFetchResults.cancel();
+    };
+  }, [searchTerm, debouncedFetchResults]); // Effect dependencies
+
+  return { searchTerm, setSearchTerm, results, loading };
+}

--- a/app/layouts/api.tsx
+++ b/app/layouts/api.tsx
@@ -1,0 +1,21 @@
+// routes/api/users/index.tsx
+import { data } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { Outlet } from "react-router-dom";
+import { getCurrentUser } from "~/services/auth.server";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getCurrentUser(request);
+
+  if (!user) {
+    throw new Response("Forbidden", { status: 403 });
+  }
+
+  return data({
+    ok: true,
+  });
+}
+
+export default function ApiLayout() {
+  return <Outlet />;
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -3,6 +3,7 @@ import { type RouteConfig, index, route } from "@react-router/dev/routes";
 export const DASHBOARD_PATH = "dashboard";
 export const LOGIN_PATH = "auth/login";
 export const REGISTER_PATH = "auth/register";
+export const API_PATH = "api";
 
 export default [
   index("routes/home.tsx"),
@@ -13,4 +14,5 @@ export default [
     index("routes/dashboard/index.tsx"),
     route("account", "routes/dashboard/account/index.tsx"),
   ]),
+  route(API_PATH, "layouts/api.tsx", [route("search", "routes/api/search.ts")]),
 ] satisfies RouteConfig;

--- a/app/routes/api.search.test.ts
+++ b/app/routes/api.search.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loader } from './api.search'; // Adjust path as necessary
+// import { prisma } from '~/db/client.server'; // This line will be problematic
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// This object will hold our mock functions.
+// It's defined outside the vi.mock factory so it can be referenced in tests.
+const prismaMockImplementation = {
+  post: { findMany: vi.fn() },
+  reportedEntity: { findMany: vi.fn() },
+  reportedEntityHandle: { findMany: vi.fn() },
+  user: { findMany: vi.fn() },
+};
+
+// Mock the entire module '~/db/client.server'.
+// The factory function (the second argument to vi.mock)
+// must return an object that represents the mocked module's exports.
+vi.mock('~/db/client.server', () => ({
+  // The module '~/db/client.server' exports an object named 'prisma'.
+  // So, our mock module must also export a 'prisma' object.
+  prisma: prismaMockImplementation,
+}));
+
+// Now that the mock is set up (Vitest hoists vi.mock calls),
+// we can import the loader function that uses the mocked prisma client.
+import { loader } from './api.search';
+
+// Make sure all imports are here, especially if types are needed from prisma/client or other places
+// For example: import type { Post, User } from '@prisma/client';
+// This specific import of prisma is only for type information if needed by tests, actual calls use prismaMock
+// For safety, avoid direct import if possible, or ensure it's only for types.
+// import type { PrismaClient } from '@prisma/client'; 
+
+
+const mockPost = {
+  id: 'post1',
+  prisma: {
+    post: { findMany: vi.fn() },
+    reportedEntity: { findMany: vi.fn() },
+    reportedEntityHandle: { findMany: vi.fn() },
+    user: { findMany: vi.fn() },
+  },
+}));
+
+const mockPost = {
+  id: 'post1',
+  description: 'This is a test post about Remix.',
+  reportedEntity: { id: 're1', name: 'Entity in Post' },
+};
+const mockReportedEntity = {
+  id: 're1',
+  name: 'Test Entity',
+  handles: [{ id: 'handle1', handle: 'testentity_ig' }],
+};
+const mockReportedEntityHandle = {
+  id: 'handle2',
+  handle: 'user_handle_ig',
+  reportedEntityId: 're2',
+  reportedEntity: { id: 're2', name: 'User Handle Parent', handles: [{id: 'handle2', handle: 'user_handle_ig'}] },
+};
+const mockUser = {
+  id: 'user1',
+  firstName: 'John',
+  lastName: 'Doe',
+  instagram: 'johndoe_ig',
+};
+
+describe('API Search Loader', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Reset mocks using the implementation object
+    prismaMockImplementation.post.findMany.mockResolvedValue([]);
+    prismaMockImplementation.reportedEntity.findMany.mockResolvedValue([]);
+    prismaMockImplementation.reportedEntityHandle.findMany.mockResolvedValue([]);
+    prismaMockImplementation.user.findMany.mockResolvedValue([]);
+  });
+
+  it('should return an empty array if search term is empty', async () => {
+    const request = new Request('http://localhost/api/search?q=');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([]);
+  });
+  
+  it('should return an empty array if search term is missing', async () => {
+    const request = new Request('http://localhost/api/search');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([]);
+  });
+
+  it('should return matching posts', async () => {
+    prismaMock.post.findMany.mockResolvedValue([mockPost]);
+    const request = new Request('http://localhost/api/search?q=Remix');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([{ type: 'post', data: mockPost }]);
+    expect(prismaMockImplementation.post.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { description: { contains: 'Remix', mode: 'insensitive' } },
+    }));
+  });
+
+  it('should return matching reported entities by name', async () => {
+    prismaMockImplementation.reportedEntity.findMany.mockResolvedValue([mockReportedEntity]);
+    const request = new Request('http://localhost/api/search?q=Test Entity');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([{ type: 'reportedEntity', data: mockReportedEntity }]);
+    expect(prismaMockImplementation.reportedEntity.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { name: { contains: 'Test Entity', mode: 'insensitive' } },
+    }));
+  });
+
+  it('should return parent reported entity for matching handles', async () => {
+    prismaMockImplementation.reportedEntityHandle.findMany.mockResolvedValue([mockReportedEntityHandle]);
+    const request = new Request('http://localhost/api/search?q=user_handle_ig');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+     // The loader now de-duplicates and returns the parent entity
+    expect(data).toEqual([{ type: 'reportedEntity', data: mockReportedEntityHandle.reportedEntity }]);
+    expect(prismaMockImplementation.reportedEntityHandle.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { handle: { contains: 'user_handle_ig', mode: 'insensitive' } },
+    }));
+  });
+  
+  it('should return matching users by first name', async () => {
+    prismaMockImplementation.user.findMany.mockResolvedValue([mockUser]);
+    const request = new Request('http://localhost/api/search?q=John');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([{ type: 'user', data: mockUser }]);
+    expect(prismaMockImplementation.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { OR: expect.arrayContaining([
+        expect.objectContaining({ firstName: { contains: 'John', mode: 'insensitive' } })
+      ])}
+    }));
+  });
+
+  it('should return matching users by last name', async () => {
+    prismaMockImplementation.user.findMany.mockResolvedValue([mockUser]);
+    const request = new Request('http://localhost/api/search?q=Doe');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([{ type: 'user', data: mockUser }]);
+     expect(prismaMockImplementation.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { OR: expect.arrayContaining([
+        expect.objectContaining({ lastName: { contains: 'Doe', mode: 'insensitive' } })
+      ])}
+    }));
+  });
+
+  it('should return matching users by Instagram handle', async () => {
+    prismaMockImplementation.user.findMany.mockResolvedValue([mockUser]);
+    const request = new Request('http://localhost/api/search?q=johndoe_ig');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([{ type: 'user', data: mockUser }]);
+    expect(prismaMockImplementation.user.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { OR: expect.arrayContaining([
+        expect.objectContaining({ instagram: { contains: 'johndoe_ig', mode: 'insensitive' } })
+      ])}
+    }));
+  });
+
+  it('should return multiple types of results and handle deduplication', async () => {
+    const commonEntity = { id: 're3', name: 'Common Entity', handles: [{id: 'h3', handle: 'common_ig'}]};
+    prismaMockImplementation.post.findMany.mockResolvedValue([{ ...mockPost, description: 'Search term common' }]);
+    prismaMockImplementation.reportedEntity.findMany.mockResolvedValue([commonEntity]);
+    // This handle search should result in commonEntity, which will be deduplicated
+    prismaMockImplementation.reportedEntityHandle.findMany.mockResolvedValue([{ id: 'h4', handle: 'common_ig_handle_variant', reportedEntity: commonEntity }]);
+    prismaMockImplementation.user.findMany.mockResolvedValue([{ ...mockUser, firstName: 'CommonUser' }]);
+    
+    const request = new Request('http://localhost/api/search?q=common');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+
+    expect(data).toContainEqual({ type: 'post', data: { ...mockPost, description: 'Search term common' } });
+    expect(data).toContainEqual({ type: 'reportedEntity', data: commonEntity });
+    expect(data).toContainEqual({ type: 'user', data: { ...mockUser, firstName: 'CommonUser' } });
+    
+    // Check for deduplication: commonEntity should only appear once
+    const entityResults = data.filter((item: any) => item.type === 'reportedEntity' && item.data.id === 're3');
+    expect(entityResults.length).toBe(1);
+    expect(data.length).toBe(3); // Post, Entity, User
+  });
+
+  it('should return an empty array if no matches are found', async () => {
+    const request = new Request('http://localhost/api/search?q=nonexistentterm123');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([]);
+  });
+  
+  it('should handle case-insensitivity for posts', async () => {
+    prismaMock.post.findMany.mockResolvedValue([mockPost]);
+    const request = new Request('http://localhost/api/search?q=remix'); // Lowercase search
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(data).toEqual([{ type: 'post', data: mockPost }]);
+    expect(prismaMockImplementation.post.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { description: { contains: 'remix', mode: 'insensitive' } },
+    }));
+  });
+
+  it('should correctly structure the response', async () => {
+    prismaMockImplementation.post.findMany.mockResolvedValue([mockPost]);
+    const request = new Request('http://localhost/api/search?q=Remix');
+    const response = await loader({ request, params: {}, context: {} });
+    const data = await response.json();
+    expect(response.headers.get('Content-Type')).toEqual('application/json; charset=utf-8');
+    expect(data[0]).toHaveProperty('type');
+    expect(data[0]).toHaveProperty('data');
+    expect(data[0].type).toBe('post');
+    expect(data[0].data).toEqual(mockPost);
+  });
+});

--- a/app/routes/api/search.test.ts
+++ b/app/routes/api/search.test.ts
@@ -1,8 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { loader } from './api.search'; // Adjust path as necessary
-// import { prisma } from '~/db/client.server'; // This line will be problematic
-
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // This object will hold our mock functions.
 // It's defined outside the vi.mock factory so it can be referenced in tests.
@@ -24,7 +20,7 @@ vi.mock('~/db/client.server', () => ({
 
 // Now that the mock is set up (Vitest hoists vi.mock calls),
 // we can import the loader function that uses the mocked prisma client.
-import { loader } from './api.search';
+import { loader } from './search';
 
 // Make sure all imports are here, especially if types are needed from prisma/client or other places
 // For example: import type { Post, User } from '@prisma/client';

--- a/app/routes/api/search.ts
+++ b/app/routes/api/search.ts
@@ -1,0 +1,79 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { prisma } from "~/db/client.server";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const q = url.searchParams.get("q");
+
+  if (!q) {
+    return json([]);
+  }
+
+  try {
+    const posts = await prisma.post.findMany({
+      where: {
+        description: {
+          contains: q,
+          mode: "insensitive",
+        },
+      },
+      include: {
+        reportedEntity: true,
+      },
+    });
+
+    const reportedEntities = await prisma.reportedEntity.findMany({
+      where: {
+        name: {
+          contains: q,
+          mode: "insensitive",
+        },
+      },
+      include: {
+        handles: true,
+      },
+    });
+
+    const reportedEntityHandles = await prisma.reportedEntityHandle.findMany({
+      where: {
+        handle: {
+          contains: q,
+          mode: "insensitive",
+        },
+      },
+      include: { 
+        reportedEntity: {
+          include: {
+            handles: true, // Also include other handles of the parent entity
+          }
+        } 
+      }
+    });
+
+    // User search removed as per requirements
+
+    const results = [
+      ...posts.map((post) => ({ type: "post", data: post })),
+      ...reportedEntities.map((entity) => ({
+        type: "reportedEntity",
+        data: entity,
+      })),
+      // Map handle search results to their parent ReportedEntity
+      // This avoids duplicate ReportedEntity entries if found by both name and handle
+      ...reportedEntityHandles.map((handle) => ({
+        type: "reportedEntity", // Change type to "reportedEntity"
+        data: handle.reportedEntity, // Return the parent entity
+      })),
+      // User results mapping removed
+    ];
+    
+    // Deduplicate results based on type and ID
+    const uniqueResults = Array.from(new Map(results.map(item => [`${item.type}-${item.data.id}`, item])).values());
+
+    return json(uniqueResults);
+  } catch (error) {
+    console.error("Search error:", error);
+    return json({ error: "Search failed" }, { status: 500 });
+  }
+}

--- a/app/test/setup-test-env.ts
+++ b/app/test/setup-test-env.ts
@@ -1,0 +1,23 @@
+// import '@testing-library/jest-dom/vitest'; // if using vitest
+import '@testing-library/jest-dom'; // if using jest or if vitest setup prefers this
+
+// You can add other global setup files here, for example, mocking a global API
+// import { server } from './mocks/server'; // Example for MSW
+// beforeAll(() => server.listen());
+// afterEach(() => server.resetHandlers());
+// afterAll(() => server.close());
+
+// Example: Mocking matchMedia for components that might use it (e.g. for responsive design)
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:studio": "prisma studio",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc",
+    "test": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -72,11 +74,21 @@
   "devDependencies": {
     "@netlify/vite-plugin-react-router": "^1.0.1",
     "@react-router/dev": "^7.5.2",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.15.18",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",
+    "@types/testing-library__jest-dom": "^6.0.0",
+    "@vitest/ui": "^3.1.4",
+    "happy-dom": "^17.4.7",
+    "msw": "^2.8.4",
+    "react-router-dom": "^7.6.0",
     "typescript": "^5.8.3",
     "vite": "^6.3.3",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.1.4"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,12 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import netlifyPlugin from "@netlify/vite-plugin-react-router";
 import devtoolsJson from "vite-plugin-devtools-json";
+import type { UserConfig } from "vite";
+import type { InlineConfig } from "vitest";
+
+interface VitestUserConfig extends UserConfig {
+  test: InlineConfig;
+}
 
 export default defineConfig({
   css: {
@@ -13,4 +19,20 @@ export default defineConfig({
     },
   },
   plugins: [reactRouter(), tsconfigPaths(), netlifyPlugin(), devtoolsJson()],
-});
+  test: {
+    globals: true,
+    environment: "happy-dom",
+    setupFiles: "./app/test/setup-test-env.ts",
+    include: ["./app/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+    watchExclude: [".*\\/node_modules\\/.*", ".*\\/build\\/.*"],
+    resolve: {
+      conditions: ['node', 'import', 'module'],
+    },
+    alias: [ // Adding alias for msw/node
+      {
+        find: /^msw\/node$/,
+        replacement: 'msw/node',
+      },
+    ],
+  },
+} as VitestUserConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adobe/css-tools@^4.4.0":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.3.tgz#beebbefb0264fdeb32d3052acae0e0d94315a9a2"
+  integrity sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
@@ -15,7 +20,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@babel/code-frame@^7.27.1":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
@@ -227,7 +232,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.27.1"
 
-"@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.1.tgz#9fce313d12c9a77507f264de74626e87fd0dc541"
   integrity sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==
@@ -261,6 +266,28 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
+
+"@bundled-es-modules/cookie@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz#b41376af6a06b3e32a15241d927b840a9b4de507"
+  integrity sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==
+  dependencies:
+    cookie "^0.7.2"
+
+"@bundled-es-modules/statuses@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz#761d10f44e51a94902c4da48675b71a76cc98872"
+  integrity sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==
+  dependencies:
+    statuses "^2.0.1"
+
+"@bundled-es-modules/tough-cookie@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz#fa9cd3cedfeecd6783e8b0d378b4a99e52bde5d3"
+  integrity sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==
+  dependencies:
+    "@types/tough-cookie" "^4.0.5"
+    tough-cookie "^4.1.4"
 
 "@dnd-kit/accessibility@^3.1.1":
   version "3.1.1"
@@ -460,6 +487,38 @@
   dependencies:
     "@standard-schema/utils" "^0.3.0"
 
+"@inquirer/confirm@^5.0.0":
+  version "5.1.11"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-5.1.11.tgz#fd5be410191a54de6b9085f39f2649824291cd13"
+  integrity sha512-HgVha2B1lurfZ8u7cBWmu60HpkpnnIT/1IrreBx5g2oxQOVYU15WQDl6oZqjuXVbzteFKSpmMkLTMf2OmbUjaw==
+  dependencies:
+    "@inquirer/core" "^10.1.12"
+    "@inquirer/type" "^3.0.7"
+
+"@inquirer/core@^10.1.12":
+  version "10.1.12"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-10.1.12.tgz#5e206c922e44e147abcc9a1ad885a544bca54402"
+  integrity sha512-uoaDadeJCYSVKYCMPwJi3AjCF9w+l9aWbHYA4iskKX84cVW/A2M6bJlWBoy3k81GpFp6EX3IElV1Z5xKw0g1QQ==
+  dependencies:
+    "@inquirer/figures" "^1.0.12"
+    "@inquirer/type" "^3.0.7"
+    ansi-escapes "^4.3.2"
+    cli-width "^4.1.0"
+    mute-stream "^2.0.0"
+    signal-exit "^4.1.0"
+    wrap-ansi "^6.2.0"
+    yoctocolors-cjs "^2.1.2"
+
+"@inquirer/figures@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-1.0.12.tgz#667d6254cc7ba3b0c010a323d78024a1d30c6053"
+  integrity sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==
+
+"@inquirer/type@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.7.tgz#b46bcf377b3172dbc768fdbd053e6492ad801a09"
+  integrity sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -491,7 +550,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
@@ -508,6 +567,18 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz#577c0c25d8aae9f69a97738b7b0d03d1471cdc49"
   integrity sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==
+
+"@mswjs/interceptors@^0.37.0":
+  version "0.37.6"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.37.6.tgz#2635319b7a81934e1ef1b5593ef7910347e2b761"
+  integrity sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==
+  dependencies:
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/logger" "^0.3.0"
+    "@open-draft/until" "^2.0.0"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    strict-event-emitter "^0.5.1"
 
 "@netlify/vite-plugin-react-router@^1.0.1":
   version "1.0.1"
@@ -573,10 +644,33 @@
   dependencies:
     which "^3.0.0"
 
+"@open-draft/deferred-promise@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz#4a822d10f6f0e316be4d67b4d4f8c9a124b073bd"
+  integrity sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==
+
+"@open-draft/logger@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/logger/-/logger-0.3.0.tgz#2b3ab1242b360aa0adb28b85f5d7da1c133a0954"
+  integrity sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==
+  dependencies:
+    is-node-process "^1.2.0"
+    outvariant "^1.4.0"
+
+"@open-draft/until@^2.0.0", "@open-draft/until@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
+  integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@polka/url@^1.0.0-next.24":
+  version "1.0.0-next.29"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
+  integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
 "@prisma/client@^6.8.2":
   version "6.8.2"
@@ -1293,6 +1387,50 @@
   resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
   integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
 
+"@testing-library/dom@^10.4.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
+  integrity sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/jest-dom@*", "@testing-library/jest-dom@^6.6.3":
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz#26ba906cf928c0f8172e182c6fe214eb4f9f2bd2"
+  integrity sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==
+  dependencies:
+    "@adobe/css-tools" "^4.4.0"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.6.3"
+    lodash "^4.17.21"
+    redent "^3.0.0"
+
+"@testing-library/react@^16.3.0":
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.3.0.tgz#3a85bb9bdebf180cd76dba16454e242564d598a6"
+  integrity sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
+
 "@types/bcryptjs@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-3.0.0.tgz#d7be11653aa82cf17ffee4f3925f1f80cfc1add2"
@@ -1356,7 +1494,7 @@
   resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
   integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
 
-"@types/estree@1.0.7":
+"@types/estree@1.0.7", "@types/estree@^1.0.0":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
@@ -1392,6 +1530,95 @@
   dependencies:
     csstype "^3.0.2"
 
+"@types/statuses@^2.0.4":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/statuses/-/statuses-2.0.5.tgz#f61ab46d5352fd73c863a1ea4e1cef3b0b51ae63"
+  integrity sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==
+
+"@types/testing-library__jest-dom@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-6.0.0.tgz#b558b64b80a72130714be1f505c6df482d453690"
+  integrity sha512-bnreXCgus6IIadyHNlN/oI5FfX4dWgvGhOPvpr7zzCYDGAPIfvyIoAozMBINmhmsVuqV0cncejF2y5KC7ScqOg==
+  dependencies:
+    "@testing-library/jest-dom" "*"
+
+"@types/tough-cookie@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
+
+"@vitest/expect@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.1.4.tgz#837651a71682e3611c3df7b58b157ba485bd8029"
+  integrity sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==
+  dependencies:
+    "@vitest/spy" "3.1.4"
+    "@vitest/utils" "3.1.4"
+    chai "^5.2.0"
+    tinyrainbow "^2.0.0"
+
+"@vitest/mocker@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.1.4.tgz#73441022b86c7299bfbd11a9fb2e99a7ddc2bb0e"
+  integrity sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==
+  dependencies:
+    "@vitest/spy" "3.1.4"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.17"
+
+"@vitest/pretty-format@3.1.4", "@vitest/pretty-format@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.1.4.tgz#da3e98c250cde3ce39fe8e709339814607b185e8"
+  integrity sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/runner@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.1.4.tgz#19fa16eb397f5325b99baca48c2bca6cadd098fa"
+  integrity sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==
+  dependencies:
+    "@vitest/utils" "3.1.4"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.1.4.tgz#7897d4960a3cf617fb0f17e182cc15c7e3e4ed3f"
+  integrity sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==
+  dependencies:
+    "@vitest/pretty-format" "3.1.4"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+
+"@vitest/spy@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.1.4.tgz#94bb566da7ef6deb7c4e1fd79b78f19aa5465b9f"
+  integrity sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/ui@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/ui/-/ui-3.1.4.tgz#ece30f41330bd26f656f737cda57c35b5121175b"
+  integrity sha512-CFc2Bpb3sz4Sdt53kdNGq+qZKLftBwX4qZLC03CBUc0N1LJrOoL0ZeK0oq/708mtnpwccL0BZCY9d1WuiBSr7Q==
+  dependencies:
+    "@vitest/utils" "3.1.4"
+    fflate "^0.8.2"
+    flatted "^3.3.3"
+    pathe "^2.0.3"
+    sirv "^3.0.1"
+    tinyglobby "^0.2.13"
+    tinyrainbow "^2.0.0"
+
+"@vitest/utils@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.1.4.tgz#f9f20d92f1384a9d66548c480885390760047b5e"
+  integrity sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==
+  dependencies:
+    "@vitest/pretty-format" "3.1.4"
+    loupe "^3.1.3"
+    tinyrainbow "^2.0.0"
+
 "@web3-storage/multipart-parser@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz#6b69dc2a32a5b207ba43e556c25cc136a56659c4"
@@ -1417,6 +1644,13 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+ansi-escapes@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -1427,12 +1661,17 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
   integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
 
-ansi-styles@^4.0.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-styles@^6.1.0:
   version "6.2.1"
@@ -1464,10 +1703,27 @@ aria-hidden@^1.2.4:
   dependencies:
     tslib "^2.0.0"
 
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
+
+aria-query@^5.0.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
+  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 autoprefixer@^10.4.21:
   version "10.4.21"
@@ -1613,6 +1869,38 @@ caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.30001716:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz#dae13a9c80d517c30c6197515a96131c194d8f82"
   integrity sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==
 
+chai@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.2.0.tgz#1358ee106763624114addf84ab02697e411c9c05"
+  integrity sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+check-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
+  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
+
 chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
@@ -1641,6 +1929,20 @@ class-variance-authority@^0.7.1:
   integrity sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==
   dependencies:
     clsx "^2.1.1"
+
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
 
 clsx@^2.0.0, clsx@^2.1.1:
   version "2.1.1"
@@ -1744,6 +2046,11 @@ cross-spawn@^7.0.6:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -1855,6 +2162,11 @@ dedent@^1.5.3:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.6.0.tgz#79d52d6389b1ffa67d2bcef59ba51847a9d503b2"
   integrity sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==
 
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
+
 define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
@@ -1868,6 +2180,11 @@ depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
 destroy@1.2.0:
   version "1.2.0"
@@ -1888,6 +2205,16 @@ dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dom-accessibility-api@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
+  integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -1956,7 +2283,7 @@ es-errors@^1.3.0:
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
-es-module-lexer@^1.3.1, es-module-lexer@^1.5.4:
+es-module-lexer@^1.3.1, es-module-lexer@^1.5.4, es-module-lexer@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
@@ -1999,7 +2326,7 @@ esbuild@^0.25.0, esbuild@~0.25.0:
     "@esbuild/win32-ia32" "0.25.4"
     "@esbuild/win32-x64" "0.25.4"
 
-escalade@^3.2.0:
+escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
@@ -2008,6 +2335,13 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
+
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
 
 etag@~1.8.1:
   version "1.8.1"
@@ -2028,6 +2362,11 @@ exit-hook@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-2.2.1.tgz#007b2d92c6428eda2b76e7016a34351586934593"
   integrity sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==
+
+expect-type@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.1.tgz#af76d8b357cf5fa76c41c09dafb79c549e75f71f"
+  integrity sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==
 
 express@^4.19.2:
   version "4.21.2"
@@ -2094,6 +2433,11 @@ fdir@^6.4.4:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.4.tgz#1cfcf86f875a883e19a8fab53622cfe992e8d2f9"
   integrity sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==
 
+fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
@@ -2113,6 +2457,11 @@ finalhandler@1.3.1:
     parseurl "~1.3.3"
     statuses "2.0.1"
     unpipe "~1.0.0"
+
+flatted@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 for-each@^0.3.5:
   version "0.3.5"
@@ -2167,6 +2516,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
   version "1.3.0"
@@ -2255,6 +2609,24 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
+graphql@^16.8.1:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.11.0.tgz#96d17f66370678027fdf59b2d4c20b4efaa8a633"
+  integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
+
+happy-dom@^17.4.7:
+  version "17.4.7"
+  resolved "https://registry.yarnpkg.com/happy-dom/-/happy-dom-17.4.7.tgz#d3a928792902086a747883f8d9753048395ad4ba"
+  integrity sha512-NZypxadhCiV5NT4A+Y86aQVVKQ05KDmueja3sz008uJfDRwz028wd0aTiJPwo4RQlvlz0fznkEEBBCHVNWc08g==
+  dependencies:
+    webidl-conversions "^7.0.0"
+    whatwg-mimetype "^3.0.0"
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 has-property-descriptors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
@@ -2281,6 +2653,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+headers-polyfill@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-4.0.3.tgz#922a0155de30ecc1f785bcf04be77844ca95ad07"
+  integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
+
 hosted-git-info@^6.0.0, hosted-git-info@^6.1.1:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-6.1.3.tgz#2ee1a14a097a1236bddf8672c35b613c46c55946"
@@ -2305,6 +2682,11 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 inherits@2.0.4, inherits@^2.0.3:
   version "2.0.4"
@@ -2374,6 +2756,11 @@ is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -2487,6 +2874,11 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^3.1.0, loupe@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
+  integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
+
 lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -2508,6 +2900,18 @@ lucide-react@^0.511.0:
   version "0.511.0"
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.511.0.tgz#1dfef3065c725ac83f5fe0a6f02d1e0b0c36e641"
   integrity sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==
+
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
+magic-string@^0.30.17:
+  version "0.30.17"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
+  integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -2564,6 +2968,11 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
 minimatch@^9.0.4:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
@@ -2592,6 +3001,11 @@ mrmime@^1.0.0:
   resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
   integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
 
+mrmime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
+  integrity sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -2601,6 +3015,35 @@ ms@2.1.3, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+msw@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-2.8.4.tgz#e61f50f5bc891e5b81655e4450650b587b761dd5"
+  integrity sha512-GLU8gx0o7RBG/3x/eTnnLd5S5ZInxXRRRMN8GJwaPZ4jpJTxzQfWGvwr90e8L5dkKJnz+gT4gQYCprLy/c4kVw==
+  dependencies:
+    "@bundled-es-modules/cookie" "^2.0.1"
+    "@bundled-es-modules/statuses" "^1.0.1"
+    "@bundled-es-modules/tough-cookie" "^0.1.6"
+    "@inquirer/confirm" "^5.0.0"
+    "@mswjs/interceptors" "^0.37.0"
+    "@open-draft/deferred-promise" "^2.2.0"
+    "@open-draft/until" "^2.1.0"
+    "@types/cookie" "^0.6.0"
+    "@types/statuses" "^2.0.4"
+    graphql "^16.8.1"
+    headers-polyfill "^4.0.2"
+    is-node-process "^1.2.0"
+    outvariant "^1.4.3"
+    path-to-regexp "^6.3.0"
+    picocolors "^1.1.1"
+    strict-event-emitter "^0.5.1"
+    type-fest "^4.26.1"
+    yargs "^17.7.2"
+
+mute-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-2.0.0.tgz#a5446fc0c512b71c83c44d908d5c7b7b4c493b2b"
+  integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
 
 mz@^2.7.0:
   version "2.7.0"
@@ -2722,6 +3165,11 @@ on-headers@~1.0.2:
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
+outvariant@^1.4.0, outvariant@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
+
 package-json-from-dist@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
@@ -2755,10 +3203,25 @@ path-to-regexp@0.1.12:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
+
 pathe@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
+  integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
 
 picocolors@^1.1.1:
   version "1.1.1"
@@ -2848,6 +3311,15 @@ prettier@^2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 prisma@^6.8.2:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/prisma/-/prisma-6.8.2.tgz#5cd9e1635b6ed0e27ea3cf3ef31c648c55115a63"
@@ -2891,12 +3363,29 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+psl@^1.1.33:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
+punycode@^2.1.1, punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
 qs@6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"
   integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
   dependencies:
     side-channel "^1.0.6"
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -2935,6 +3424,11 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-is@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
@@ -2964,7 +3458,14 @@ react-remove-scroll@^2.6.3:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
 
-react-router@^7.0.1, react-router@^7.5.2:
+react-router-dom@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.6.0.tgz#eadcede43856dc714fa3572a946fd7502775c017"
+  integrity sha512-DYgm6RDEuKdopSyGOWZGtDfSm7Aofb8CCzgkliTjtu/eDuB0gcsv6qdFhhi8HdtmA+KHkt5MfZ5K2PdzjugYsA==
+  dependencies:
+    react-router "7.6.0"
+
+react-router@7.6.0, react-router@^7.0.1, react-router@^7.5.2:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.6.0.tgz#e2d0872d7bea8df79465a8bba9a20c87c32ce995"
   integrity sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==
@@ -3044,6 +3545,14 @@ recharts@^2.15.3:
     tiny-invariant "^1.3.1"
     victory-vendor "^36.6.8"
 
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
 remix-auth-form@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remix-auth-form/-/remix-auth-form-3.0.0.tgz#f4a84cc27f10c929cf8f2b78b85b8ba2b0b451c9"
@@ -3058,6 +3567,16 @@ remix-themes@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/remix-themes/-/remix-themes-2.0.4.tgz#7954a7d4fb38e1ca9d8abb1c4a6b7ec3b4a4d11f"
   integrity sha512-S1vIx86xdsMv+ceaWGWtlVZBMhU4tmZeBOBzOiZnhbHnGBbd5YeyIlZ5EL3BSEhZq35oEcINeTrMrVju9GPYEA==
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-pkg-maps@^1.0.0:
   version "1.0.0"
@@ -3261,10 +3780,24 @@ side-channel@^1.0.6:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
-signal-exit@^4.0.1:
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
+sirv@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.1.tgz#32a844794655b727f9e2867b777e0060fbe07bf3"
+  integrity sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==
+  dependencies:
+    "@polka/url" "^1.0.0-next.24"
+    mrmime "^2.0.0"
+    totalist "^3.0.0"
 
 sonner@^2.0.3:
   version "2.0.3"
@@ -3320,18 +3853,41 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz#6d6e980c9df2b6fc905343a3b2d702a6239536c3"
   integrity sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==
 
-statuses@2.0.1:
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+statuses@2.0.1, statuses@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+std-env@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
+  integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
 
 stream-slice@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/stream-slice/-/stream-slice-0.1.2.tgz#2dc4f4e1b936fb13f3eb39a2def1932798d07a4b"
   integrity sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+strict-event-emitter@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
+  integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
+
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3349,8 +3905,14 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3364,6 +3926,13 @@ strip-ansi@^7.0.1:
   dependencies:
     ansi-regex "^6.0.1"
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 sucrase@^3.35.0:
   version "3.35.0"
   resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.35.0.tgz#57f17a3d7e19b36d8995f06679d121be914ae263"
@@ -3376,6 +3945,13 @@ sucrase@^3.35.0:
     mz "^2.7.0"
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -3439,6 +4015,16 @@ tiny-invariant@^1.3.1:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
 tinyglobby@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.13.tgz#a0e46515ce6cbcd65331537e57484af5a7b2ff7e"
@@ -3446,6 +4032,21 @@ tinyglobby@^0.2.13:
   dependencies:
     fdir "^6.4.4"
     picomatch "^4.0.2"
+
+tinypool@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
+  integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -3458,6 +4059,21 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+totalist@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
+  integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
+
+tough-cookie@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
+  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
 
 ts-interface-checker@^0.1.9:
   version "0.1.13"
@@ -3489,6 +4105,16 @@ turbo-stream@2.4.1:
   resolved "https://registry.yarnpkg.com/turbo-stream/-/turbo-stream-2.4.1.tgz#c1a64397724084c09b0f6ea4a2c528d3f67931f9"
   integrity sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw==
 
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^4.26.1:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -3512,6 +4138,11 @@ undici@^6.19.2, undici@^6.21.2:
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.3.tgz#185752ad92c3d0efe7a7d1f6854a50f83b552d7a"
   integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
@@ -3529,6 +4160,14 @@ update-browserslist-db@^1.1.3:
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 use-callback-ref@^1.3.3:
   version "1.3.3"
@@ -3637,6 +4276,17 @@ vite-node@3.0.0-beta.2:
     pathe "^1.1.2"
     vite "^5.0.0 || ^6.0.0"
 
+vite-node@3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.1.4.tgz#13f10b2cb155197a971cb2761664ec952c6cae18"
+  integrity sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.0"
+    es-module-lexer "^1.7.0"
+    pathe "^2.0.3"
+    vite "^5.0.0 || ^6.0.0"
+
 vite-plugin-devtools-json@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/vite-plugin-devtools-json/-/vite-plugin-devtools-json-0.1.0.tgz#a9275a20ad9df3bbcaa5ee2880c9ad83e4fec72c"
@@ -3667,6 +4317,33 @@ vite-tsconfig-paths@^5.1.4:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vitest@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.1.4.tgz#5f495b7dbb1d4d208b88508cd4dfceb006f8b7e6"
+  integrity sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==
+  dependencies:
+    "@vitest/expect" "3.1.4"
+    "@vitest/mocker" "3.1.4"
+    "@vitest/pretty-format" "^3.1.4"
+    "@vitest/runner" "3.1.4"
+    "@vitest/snapshot" "3.1.4"
+    "@vitest/spy" "3.1.4"
+    "@vitest/utils" "3.1.4"
+    chai "^5.2.0"
+    debug "^4.4.0"
+    expect-type "^1.2.1"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.13"
+    tinypool "^1.0.2"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0"
+    vite-node "3.1.4"
+    why-is-node-running "^2.3.0"
+
 web-encoding@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
@@ -3680,6 +4357,16 @@ web-streams-polyfill@^3.1.1:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
 which-typed-array@^1.1.16, which-typed-array@^1.1.2:
   version "1.1.19"
@@ -3708,7 +4395,33 @@ which@^3.0.0:
   dependencies:
     isexe "^2.0.0"
 
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
+
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -3726,6 +4439,11 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -3735,6 +4453,29 @@ yaml@^2.3.4:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
   integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yoctocolors-cjs@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
+  integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
 
 zod@^3.25.7:
   version "3.25.7"


### PR DESCRIPTION
Implements a new API route for searching posts and reported entities,
and integrates this into the SearchBar component.

Key changes:
- Added a new API endpoint at `/api/search` (located in `app/routes/api/search.ts`)
  that searches `Post` descriptions, `ReportedEntity` names, and
  `ReportedEntityHandle` handles. Search is case-insensitive.
- Created a `useSearch` React hook (`app/hooks/useSearch.ts`) to encapsulate
  search logic, including state management for search term, results,
  and loading status.
- API calls within the `useSearch` hook are debounced using
  `lodash-es/debounce`.
- Refactored the `SearchBar` component (`app/components/search-bar.tsx`)
  to use the `useSearch` hook, simplifying its implementation.