### PR TITLE
feat: display user spaces sidebar

### DIFF
--- a/.react-router/types/+register.ts
+++ b/.react-router/types/+register.ts
@@ -17,4 +17,5 @@ type Params = {
   "/auth/logout": {};
   "/dashboard": {};
   "/dashboard/account": {};
+  "/resources/api/spaces": {};
 };

--- a/app/components/app-sidebar/index.tsx
+++ b/app/components/app-sidebar/index.tsx
@@ -39,7 +39,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </SidebarHeader>
       <SidebarContent>
         <NavMain items={data.navMain} />
-        <NavSpaces items={data.spaces} />
+        {data.spaces && data.spaces.length > 0 && (
+          <NavSpaces items={data.spaces} />
+        )}
         <NavSecondary items={data.navSecondary} className="mt-auto" />
       </SidebarContent>
       <SidebarFooter>

--- a/app/components/app-sidebar/useSidebarNav.ts
+++ b/app/components/app-sidebar/useSidebarNav.ts
@@ -7,8 +7,11 @@ import {
   SparkleIcon,
 } from "lucide-react";
 import { logout } from "~/lib/api";
+import { useSpaces, type SpaceNavItem } from '~/hooks/useSpaces';
 
 export const useSidebarNav = () => {
+  const { spaces } = useSpaces();
+
   const data = {
     user: {
       name: "shadcn",
@@ -58,20 +61,7 @@ export const useSidebarNav = () => {
         },
       },
     ],
-    spaces: [
-      {
-        name: "Lyon",
-        url: "#",
-      },
-      {
-        name: "Paris",
-        url: "#",
-      },
-      {
-        name: "Model Agency Elitel",
-        url: "#",
-      },
-    ],
+    spaces: spaces,
   };
 
   return { data };

--- a/app/db/index.server.ts
+++ b/app/db/index.server.ts
@@ -1,2 +1,3 @@
 export * from './client.server'
 export * as postRepository from './repositories/posts'
+export * as spaceRepository from './repositories/spaces';

--- a/app/db/repositories/spaces/index.server.ts
+++ b/app/db/repositories/spaces/index.server.ts
@@ -1,0 +1,1 @@
+export * from './queries.server';

--- a/app/db/repositories/spaces/queries.server.ts
+++ b/app/db/repositories/spaces/queries.server.ts
@@ -1,0 +1,26 @@
+import { prisma } from '~/db/client.server';
+import type { UserSpaceMembership, Space } from '~/generated/prisma';
+
+interface UserSpace extends Pick<Space, 'id' | 'name'> {
+  role: UserSpaceMembership['role'];
+}
+
+export async function getUserSpaces(userId: string): Promise<UserSpace[]> {
+  const memberships = await prisma.userSpaceMembership.findMany({
+    where: { userId: userId },
+    include: {
+      space: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  return memberships.map(membership => ({
+    id: membership.space.id,
+    name: membership.space.name,
+    role: membership.role,
+  }));
+}

--- a/app/hooks/useSpaces.ts
+++ b/app/hooks/useSpaces.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { spaceRepository } from "~/db";
+import { useUser } from "~/hooks/useUser";
+
+export interface SpaceNavItem {
+  id: string;
+  name: string;
+  url: string;
+}
+
+export const useSpaces = () => {
+  const [spaces, setSpaces] = useState<SpaceNavItem[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const user = useUser();
+
+  useEffect(() => {
+    if (user && user.id) {
+      setIsLoading(true);
+      spaceRepository.getUserSpaces(user.id)
+        .then(userSpaces => {
+          const formattedSpaces = userSpaces.map(space => ({
+            id: space.id,
+            name: space.name,
+            url: `/dashboard/spaces/${space.id}`,
+          }));
+          setSpaces(formattedSpaces);
+        })
+        .catch(error => {
+          console.error("Failed to fetch user spaces:", error);
+          setSpaces([]);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    } else {
+      setSpaces([]);
+      setIsLoading(false);
+    }
+  }, [user, user?.id]);
+
+  return { spaces, isLoading };
+};

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,4 +13,5 @@ export default [
     index("routes/dashboard/index.tsx"),
     route("account", "routes/dashboard/account/index.tsx"),
   ]),
+  route("resources/api/spaces", "routes/api.spaces.ts"),
 ] satisfies RouteConfig;

--- a/app/routes/api.spaces.ts
+++ b/app/routes/api.spaces.ts
@@ -1,0 +1,15 @@
+import { data, type LoaderFunction } from "@remix-run/node";
+import { getCurrentUser } from "~/services/auth.server";
+import { getUserSpaces } from "~/db/repositories/spaces/queries.server";
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const user = await getCurrentUser(request);
+  if (!user) {
+    throw new Response("User not found", { status: 401 });
+  }
+  const spaces = await getUserSpaces(user.id);
+
+  return data({ spaces });
+};
+
+// No default export needed for API routes


### PR DESCRIPTION
- Created a `spaceRepository` with `getUserSpaces` to retrieve your associated spaces.
- Dynamically populated the sidebar's `NavSpaces` component with these spaces.
- Introduced `useSpaces` hook (`app/hooks/useSpaces.ts`) to encapsulate space-fetching logic, including loading states.
- Refactored `useSidebarNav` to use `useSpaces`, simplifying its responsibilities.
- Updated `AppSidebar` to conditionally render `NavSpaces` only if spaces are present.