### PR TITLE
feat: Add SuperAdmin dashboard

### DIFF
--- a/app/components/nav-main.tsx
+++ b/app/components/nav-main.tsx
@@ -1,4 +1,6 @@
-import { MailIcon, PlusCircleIcon, type LucideIcon } from "lucide-react"
+import { MailIcon, PlusCircleIcon, ShieldCheckIcon, type LucideIcon } from "lucide-react"
+import { useRouteLoaderData } from "@remix-run/react"
+import type { User } from "~/generated/prisma"
 
 import { Button } from "~/components/ui/button"
 import {
@@ -18,6 +20,8 @@ export function NavMain({
     icon?: LucideIcon
   }[]
 }) {
+  const { user } = useRouteLoaderData("root") as { user: User }
+
   return (
     <SidebarGroup>
       <SidebarGroupContent className="flex flex-col gap-2">
@@ -33,9 +37,17 @@ export function NavMain({
           </SidebarMenuItem>
         </SidebarMenu>
         <SidebarMenu>
+          {user && user.isSuperAdmin && (
+            <SidebarMenuItem>
+              <SidebarMenuButton tooltip="SuperAdmin Dashboard" href="/dashboard/superadmin">
+                <ShieldCheckIcon />
+                <span>SuperAdmin Dashboard</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          )}
           {items.map((item) => (
             <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton tooltip={item.title}>
+              <SidebarMenuButton tooltip={item.title} href={item.url}>
                 {item.icon && <item.icon />}
                 <span>{item.title}</span>
               </SidebarMenuButton>

--- a/app/db/index.server.ts
+++ b/app/db/index.server.ts
@@ -1,3 +1,4 @@
 export * from './client.server'
 export * as postRepository from './repositories/posts'
 export * as spaceRepository from './repositories/spaces';
+export * as userRepository from './repositories/users.server';

--- a/app/db/repositories/posts/queries.server.ts
+++ b/app/db/repositories/posts/queries.server.ts
@@ -46,6 +46,10 @@ export async function getUserPosts(
   });
 }
 
+export async function getTotalPosts() {
+  return prisma.post.count();
+}
+
 export async function getSpacePosts(
   userId: string,
   options: GetSpacePostsOptions = {}

--- a/app/db/repositories/spaces/queries.server.ts
+++ b/app/db/repositories/spaces/queries.server.ts
@@ -24,3 +24,7 @@ export async function getUserSpaces(userId: string): Promise<UserSpace[]> {
     role: membership.role,
   }));
 }
+
+export async function getTotalSpaces() {
+  return prisma.space.count();
+}

--- a/app/db/repositories/users.server.ts
+++ b/app/db/repositories/users.server.ts
@@ -1,0 +1,5 @@
+import { prisma } from '~/db/client.server';
+
+export async function getTotalUsers() {
+  return prisma.user.count();
+}

--- a/app/routes/dashboard/superadmin.tsx
+++ b/app/routes/dashboard/superadmin.tsx
@@ -1,0 +1,81 @@
+import { getCurrentUser } from "~/services/auth.server.ts";
+import { getTotalUsers } from "~/db/repositories/users.server.ts";
+import { getTotalSpaces } from "~/db/repositories/spaces/queries.server.ts";
+import { getTotalPosts } from "~/db/repositories/posts/queries.server.ts";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "~/components/ui/card";
+import { redirect, useLoaderData } from "remix-router";
+import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+
+export const meta: MetaFunction = () => ({
+  title: "SuperAdmin Dashboard",
+});
+
+export const handle = {
+  crumb: "SuperAdmin Dashboard",
+};
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const user = await getCurrentUser(request);
+
+  if (!user) {
+    return redirect("/auth/login");
+  }
+
+  if (!user.isSuperAdmin) {
+    return redirect("/dashboard");
+  }
+
+  const [totalUsers, totalSpaces, totalPosts] = await Promise.all([
+    getTotalUsers(),
+    getTotalSpaces(),
+    getTotalPosts(),
+  ]);
+
+  return {
+    totalUsers,
+    totalSpaces,
+    totalPosts,
+  };
+};
+
+export default function SuperAdminDashboard() {
+  const { totalUsers, totalSpaces, totalPosts } = useLoaderData();
+
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <Card>
+        <CardHeader>
+          <CardTitle>Total Users</CardTitle>
+          <CardDescription>The total number of registered users.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{totalUsers}</p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Total Spaces</CardTitle>
+          <CardDescription>The total number of created spaces.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{totalSpaces}</p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Total Posts</CardTitle>
+          <CardDescription>The total number of created posts.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold">{totalPosts}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Introduces a new SuperAdmin dashboard accessible via the main navigation.

Key changes:
- Added database queries to count total users, spaces, and posts.
- Created a new route `/dashboard/superadmin` that displays these counts in cards.
- Implemented access control for the dashboard, restricting it to users with the `isSuperAdmin` flag.
- Added a "SuperAdmin Dashboard" link to the main navigation, visible only to super admins.